### PR TITLE
add `/p` translatable path flag to WSLENV

### DIFF
--- a/wsl_gui_autoinstall.bat
+++ b/wsl_gui_autoinstall.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-set WSLENV=%WSLENV%:WINTMP
+set WSLENV=%WSLENV%:WINTMP/p
 set WINTMP=%TMP%
 set LINUXTMP='$(wslpath -u \"$WINTMP\")'
 


### PR DESCRIPTION
See https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows/

At least on version 1909 the script fails otherwise, because it doesn't translate the path correctly and sends `C:/` etc to bash.  (I figured `wslpath` would take care of it, but for whatever reason it doesn't.)